### PR TITLE
Remedy Generic Update V3 - Allows multiple fields to set in one call.

### DIFF
--- a/handlers/remedy_generic_update_v3/CHANGELOG
+++ b/handlers/remedy_generic_update_v3/CHANGELOG
@@ -1,0 +1,7 @@
+V3 (2019-02-16)
+ * Updated to allow a JSON object to set multiple values at once.
+V2 (2013-07-16)
+ * Fixed a bug to allow this to be used for
+   multiple forms in one task engine instance.
+Remedy Generic Update (2012-05-29)
+ * Initial version.  See README for details.

--- a/handlers/remedy_generic_update_v3/README
+++ b/handlers/remedy_generic_update_v3/README
@@ -1,0 +1,29 @@
+== Remedy Generic Update
+Updates the specified fields on the specified form for the
+specific request id.
+
+For more information, see the Detailed Description section below.
+
+=== Parameters
+[Remedy Form]
+	Remedy Form Name (not display name), eg. People is CTM:People
+[Request ID]
+	Request ID (Field 1) of record to update
+[Field Values]
+	JSON mapping of fields to set values
+
+=== Sample Configuration
+Remedy Form::     CTM:People
+Request ID::		  <%=@results['retrieve person']['Person ID']%>
+Field Values::    <%={"Email Address" => @answers['New Email'], "Nickname" => @answers['Nickname']}.to_json%>
+
+=== Results
+[request_id]
+  The request id (field 1) of the updated record.
+
+=== Detailed Description
+This handler updates the request id specified in the Request ID parameter for
+the form specified in the Remedy Form parameter with data provided in the
+Field Values parameter.  Provide a JSON object as the Field Values input to
+update the appropriate fields.
+Example:  {"Field A":"Value A","Field B":"Value B"}

--- a/handlers/remedy_generic_update_v3/handler/init.rb
+++ b/handlers/remedy_generic_update_v3/handler/init.rb
@@ -1,0 +1,148 @@
+# Require the REXML ruby library.
+require 'rexml/document'
+# Require the ArsModels ruby gem.  This is a Ruby helper library that wraps many
+# of the common Remedy operations.
+require 'ars_models'
+
+class RemedyGenericUpdateV3
+  # Prepare for execution by pre-loading Ars form definitions, building Hash
+  # objects for necessary values, and validating the present state.  This method
+  # sets the following instance variables:
+  # * @input_document - A REXML::Document object that represents the input Xml.
+  # * @debug_logging_enabled - A Boolean value indicating whether logging should
+  #   be enabled or disabled.
+  # * @parameters - A Hash of parameter names to parameter values.
+  #
+  # This is a required method that is automatically called by the Kinetic Task
+  # Engine.
+  #
+  # ==== Parameters
+  # * +input+ - The String of Xml that was built by evaluating the node.xml
+  #   handler template.
+  def initialize(input)
+    # Set the input document attribute
+    @input_document = REXML::Document.new(input)
+
+    # Determine if debug logging is enabled.
+    @debug_logging_enabled = get_info_value(@input_document, 'enable_debug_logging') == 'Yes'
+    puts("Logging enabled.") if @debug_logging_enabled
+
+    # Store parameters in the node.xml in a hash attribute named @parameters.
+    @parameters = {}
+    REXML::XPath.match(@input_document, '/handler/parameters/parameter').each do |node|
+      @parameters[node.attribute('name').value] = node.text
+    end
+    puts("Parameters: #{@parameters.inspect}") if @debug_logging_enabled
+
+
+    # Initialize the handler and pre-load form definitions using the credentials
+    # supplied by the task info items.
+    preinitialize_on_first_load(@input_document, [])
+  end
+
+  # Uses the Remedy Login ID to retrieve a single entry from the ITSM v7.x
+  # CTM:People form.  The purpose of this is to return data elements associated
+  # to the entry found.
+  #
+  # This is a required method that is automatically called by the Kinetic Task
+  # Engine.
+  #
+  # ==== Returns
+  # An Xml formatted String representing the return variable results.
+  def execute()
+
+  	@field_values = {}
+	  #@field_values[@parameters['field_name']] = @parameters['new_field_value']
+    @field_values = JSON.parse(@parameters['field_values'])
+
+    # Retrieve a single entry from specified form with given request id
+    submission = get_remedy_form(@parameters['form']).find_entries(
+      :single,
+      :conditions => [%|'1' = "#{@parameters['request_id']}"|],
+      :fields => nil
+    )
+
+	# Raise error if unable to locate the entry
+	raise("No matching entry on the #{@parameters['form']} form for the given field 1 [#{@parameters['request_id']}]") if submission.nil?
+
+	# Update customer survey base entry and specify the fields we want to return
+    submission.update_attributes!(@field_values)
+
+    # Build the results to be returned by this handler
+    results = <<-RESULTS
+    <results>
+      <result name="request_id">#{escape(submission.id)}</result>
+    </results>
+    RESULTS
+	puts(results) if @debug_logging_enabled
+
+	# Return the results String
+    return results
+  end
+
+  # This method is an accessor for the @@remedy_forms variable that caches form
+  # definitions.  It checks to see if the specified form has been loaded if so
+  # it returns it otherwise it needs to load the form and add it to the cache.
+  def get_remedy_form(form_name)
+	if @@remedy_forms[form_name].nil?
+		@@remedy_forms[form_name] = ArsModels::Form.find(form_name, :context => @@remedy_context)
+	end
+	if @@remedy_forms[form_name].nil?
+		raise "Could not find form " + form_name
+	end
+	@@remedy_forms[form_name]
+  end
+
+  ##############################################################################
+  # General handler utility functions
+  ##############################################################################
+
+  # Preinitialize expensive operations that are not task node dependent (IE
+  # don't change based on the input parameters passed via xml to the #initialize
+  # method).  This will very frequently utilize task info items to do things
+  # such as pre-load a Remedy form or generate a Remedy proxy user.
+  def preinitialize_on_first_load(input_document, form_names)
+    # Unless this method has already been called...
+    unless self.class.class_variable_defined?('@@preinitialized')
+      # Initialize a remedy context (login) account to execute the Remedy queries.
+      @@remedy_context = ArsModels::Context.new(
+        :server         => get_info_value(input_document, 'server'),
+        :username       => get_info_value(input_document, 'username'),
+        :password       => get_info_value(input_document, 'password'),
+        :port           => get_info_value(input_document, 'port'),
+        :prognum        => get_info_value(input_document, 'prognum'),
+        :authentication => get_info_value(input_document, 'authentication')
+      )
+      # Initialize the remedy forms that will be used by this handler.
+      @@remedy_forms = form_names.inject({}) do |hash, form_name|
+        hash.merge!(form_name => ArsModels::Form.find(form_name, :context => @@remedy_context))
+      end
+      # Store that we are preinitialized so that this method is not called twice.
+      @@preinitialized = true
+    end
+  end
+
+  # This is a template method that is used to escape results values (returned in
+  # execute) that would cause the XML to be invalid.  This method is not
+  # necessary if values do not contain character that have special meaning in
+  # XML (&, ", <, and >), however it is a good practice to use it for all return
+  # variable results in case the value could include one of those characters in
+  # the future.  This method can be copied and reused between handlers.
+  def escape(string)
+    # Globally replace characters based on the ESCAPE_CHARACTERS constant
+    string.to_s.gsub(/[&"><]/) { |special| ESCAPE_CHARACTERS[special] } if string
+  end
+  # This is a ruby constant that is used by the escape method
+  ESCAPE_CHARACTERS = {'&'=>'&amp;', '>'=>'&gt;', '<'=>'&lt;', '"' => '&quot;'}
+
+  # This is a sample helper method that illustrates one method for retrieving
+  # values from the input document.  As long as your node.xml document follows
+  # a consistent format, these type of methods can be copied and reused between
+  # handlers.
+  def get_info_value(document, name)
+    # Retrieve the XML node representing the desired info value
+    info_element = REXML::XPath.first(document, "/handler/infos/info[@name='#{name}']")
+    # If the desired element is nil, return nil; otherwise return the text value of the element
+    info_element.nil? ? nil : info_element.text
+  end
+end

--- a/handlers/remedy_generic_update_v3/process/info.xml
+++ b/handlers/remedy_generic_update_v3/process/info.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+This file contains a list of all configurable values used by the task node.
+
+The name of the parameter is defined by applying the 'name' attribute to the
+info tag.  For example, to define a parameter named 'username' add the
+following line:
+<info name="username" description="The username used to login"></info>
+
+Default values may be defined by placing the value of the parameter
+within the info tags.  For example, to define a parameter named 'username'
+with a default value of 'KD_WEBUSER' add the following line:
+<info name="username">KD_WEBUSER</info>
+-->
+<taskInfo version="1.0">
+  <info name="server" description="Remedy Server Name or IP Address"></info>
+  <info name="username" description="Remedy Login Name"></info>
+  <info name="password" type="encrypted" description="Remedy Password"></info>
+  <info name="port" description="Remedy TCP Port">0</info>
+  <info name="prognum" description="Remedy RPC Prognum">0</info>
+  <info name="authentication" description="Remedy Authentication String"></info>
+  <info name="enable_debug_logging" description="Enable debug logging if the value is set to 'Yes'.">No</info>
+</taskInfo>

--- a/handlers/remedy_generic_update_v3/process/node.xml
+++ b/handlers/remedy_generic_update_v3/process/node.xml
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<taskDefinition id="remedy_generic_update" name="Remedy Generic Update" schema_version="1.0" version="3">
+    <author>anne.ramey@kineticdata.com</author>
+    <description>
+	    Updates a single Remedy entry related to the form entered with
+		the Request ID specified. Updates field specified to value specified.
+	</description>
+    <helpurl>http://ktc.kineticdata.com/handler/remedy_generic_find_single</helpurl>
+    <visible>true</visible>
+    <deferrable>false</deferrable>
+    <parameters>
+        <parameter id="form" label="Remedy Form:" required="true"
+          tooltip="Remedy Form Name (not display name), eg. People is CTM:People"/>
+        <parameter id="request_id" label="Request ID:" required="true"
+          tooltip="Request ID (Field 1) of record to update"/>
+        <parameter id="field_values" label="Field Values" required="true"
+          tooltip="JSON mapping of field values" />
+    </parameters>
+    <handler name="remedy_generic_update" version="3">
+        <infos>
+            <info name="server">&lt;%= @info['server'] %&gt;</info>
+            <info name="username">&lt;%= @info['username'] %&gt;</info>
+            <info name="password">&lt;%= @info['password'] %&gt;</info>
+            <info name="port">&lt;%= @info['port'] %&gt;</info>
+            <info name="prognum">&lt;%= @info['prognum'] %&gt;</info>
+            <info name="authentication">&lt;%= @info['authentication'] %&gt;</info>
+            <info name="enable_debug_logging">&lt;%= @info['enable_debug_logging'] %&gt;</info>
+        </infos>
+        <parameters>
+            <parameter name="form">&lt;%= @parameters['form'] %&gt;</parameter>
+            <parameter name="request_id">&lt;%= @parameters['request_id'] %&gt;</parameter>
+            <parameter name="field_values">&lt;%= @parameters['field_values'] %&gt;</parameter>
+        </parameters>
+    </handler>
+    <results format="xml">
+        <result name="request_id"/>
+    </results>
+</taskDefinition>

--- a/handlers/remedy_generic_update_v3/test/simple_input.rb
+++ b/handlers/remedy_generic_update_v3/test/simple_input.rb
@@ -1,0 +1,16 @@
+{
+  'info' => {
+    'server' => '',
+    'username' => '',
+    'password' => '',
+    'port' => '',
+    'prognum' => '',
+    'authentication' => '',
+    'enable_debug_logging' => 'Yes'
+  },
+  'parameters' => {
+	'form' => 'HPD:Help Desk',
+  'request_id' => 'INC000000002012',
+	'field_values' => '{"Assignee Login ID":"matthew.howe@kineticdata.com","Assignee":"Matt Howe"}'
+  }
+}

--- a/handlers/remedy_generic_update_v3/test/simple_output.xml
+++ b/handlers/remedy_generic_update_v3/test/simple_output.xml
@@ -1,0 +1,3 @@
+<results>
+      <result name="request_id">.+</result>
+</results>


### PR DESCRIPTION
This handler was written back in February 2019 (I must not have committed it to the repo at that time).  This version allows multiple fields to be set in the update.  Previous versions only set a single field.