### PR TITLE
Update init.rb

### DIFF
--- a/handlers/ars_rest_generic_create_v1/handler/init.rb
+++ b/handlers/ars_rest_generic_create_v1/handler/init.rb
@@ -171,9 +171,8 @@ class ArsRestGenericCreateV1
         results = response.code
         #if sucessful code will be 200 and the body will be the token for further calls
         #if there is an error response.body will contain the errror in HTML
-        if response.code == 200
           puts(result.body) if @debug_logging_enabled
-          return result.body
+          return response.body
         else
           return response.code.to_s
         end


### PR DESCRIPTION
Change "return result.body" to "return response.body".  This conforms with changes to ars_rest_api_v1 and prevents error "header field value cannot include CR/LF"